### PR TITLE
README updated, offline transaction sends tokens to another account.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,24 @@ who in turn represents a single failure point.
 2. You will need to have solana-cli installed and working in order to use the program:
 [solana-cli](https://docs.solana.com/cli/install-solana-cli-tools)
 
+## <a name="Problems"></a> Problems
+It was found experimentally that it is not possible to send a native SOL token using multisig via
+`solana transfer` [command](https://docs.solana.com/ru/cli/transfer-tokens#send-tokens). The multisig confirmation
+can only be applied to tokens that were created by you
+[personally](https://spl.solana.com/token#example-creating-your-own-fungible-token) `spl-token create-token`,
+or if it is a [wrapped](https://spl.solana.com/token#example-wrapping-sol-in-a-token) SOL. 
+
+This means you have to first wrap the native Sol into some WrappedSOL, then [transfer](https://spl.solana.com/token#example-transferring-tokens-to-another-user)
+the WrappedSOL, and then unwrap it back to get the original token. 
+
 ## Implementation
-The program relies on software within the spl-token program in order to create a multisig wallet. This is being
-repurposed for storage and transfer of wrapped SOL, or any other SPL token; the program is intended to be used for
-multisig control of an SPL token mint authority. The Demo programs take SOL from a single-key wallet, wraps it as an
-SPL (token address = So11111111111111111111111111111111111111112), then sends to the spl-token multisig address. Finally,
-to demonstrate retrieval, a signing ritual is performed to transfer the wrapped SOL from the multisig account back to the 
-original sender, and unwraps back to native SOL.
+The program relies on software within the [spl-token](https://spl.solana.com/token#multisig-usage) program in order 
+to create a multisig wallet. This is being repurposed for storage and transfer of wrapped SOL, or any other SPL token; the program is intended to be used for
+multisig control of an SPL token mint [authority](https://docs.solana.com/offline-signing/durable-nonce#nonce-authority). 
+
+The Demo programs take SOL from a single-key wallet, [wraps](#Problems) it as an
+SPL (token address = So11111111111111111111111111111111111111112), then sends to the spl-token multisig address.Finally,
+to demonstrate retrieval, a signing ritual is performed to transfer the wrapped SOL from the multisig account to another account. 
 
 ## How to run
 ```
@@ -45,11 +56,14 @@ original sender, and unwraps back to native SOL.
 ```
 
 ## Presigner error issue
-You can see that in the offline signing method, where the signatures are 
-accumulated separately, using the --sign-only flag the result when attempting
+You can see that in the [offline signing method](https://spl.solana.com/token#example-offline-signing-with-multisig), 
+where the signatures are accumulated separately, using the --sign-only flag the result when attempting
 the transfer with combined signatures fails with "presigner error" message.
 Conversely, if you have all of the signatures in one place (see: multisig_w_online_signers_demo.sh),
 the transaction goes through.
+
+This problem was solved by the introduction of additional flags, which were spotted 
+[here](https://github.com/solana-labs/solana-program-library/issues/1805).
 
 ## Contribute
 The code here is open source, and I welcome anybody who is interested in this use case to contribute. 

--- a/multisig_w_offline_signers_demo.sh
+++ b/multisig_w_offline_signers_demo.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+echo "------------Step 0. Initial preparation------------"
 #Official version: demo of "presigner error" that comes with creating a multisig wallet.
 echo "hello world"
 url="https://api.devnet.solana.com"
 solana config set --url $url
+echo ""
 
+echo "------------Step 1. Creating the keypairs for the multisig------------"
 # Create keypairs for the multisig
 # hard-coded 2/3 multisig. Not yet extensible to 3/5, 4/9, 7/12, etc.
-echo "creating the keypairs for the multisig"
 for i in {1..3}
 do
     solana-keygen new --no-bip39-passphrase -o signer${i}.json;
@@ -21,14 +23,14 @@ signer2Pubkey=`solana-keygen pubkey $signer2`
 signer3Pubkey=`solana-keygen pubkey $signer3`
 echo ""
 
+echo "------------Step 2. Setting up the fee payer account, which is signer1.json keypair by default------------"
 # Set up your fee payer
-echo "setting up the fee payer account, which is signer1.json keypair by default"
-solana airdrop 1 $signer1Pubkey
 feePayer=$signer1
+solana airdrop 1 $signer1Pubkey
 solana config set --keypair $signer1
 echo ""
 
-# create the multisig
+echo "------------Step 3. Create the multisig and wrapping some SOL------------"
 echo "creating the mutisig account"
 multisigAddress=`spl-token create-multisig 2 $signer1Pubkey $signer2Pubkey $signer3Pubkey | grep multisig | xargs -n 1 | tail -n -1`
 echo "multisigAddress: $multisigAddress"
@@ -38,24 +40,28 @@ echo ""
 amount=0.75
 wSOLTokenAddress=So11111111111111111111111111111111111111112 #NOTE! Unwrap the token and it deletes the associated wSOL address!
 
-# create some wrapped sol using the signer1 address 
+# create some wrapped sol using the signer1 address
 echo "wrapping some SOL"
 spl-token wrap $amount $signer1
 echo "sending wrapped sol to $multisigAddress"
 amountActual=`spl-token accounts | grep $wSOLTokenAddress | xargs -n 1 | tail -n -1`
+echo amountActual
 spl-token transfer --fund-recipient $wSOLTokenAddress $amountActual $multisigAddress
-echo "check the balance"
+echo "check the balance multisig"
 spl-token accounts --owner $multisigAddress
+echo "check the balance owner1"
+spl-token accounts --owner $signer1Pubkey
 echo ""
 
+echo "------------Step 4. Creating and setting up the nonce account------------"
 # create a nonce account for handling offline signing, and coordinating blockhash of the multisig account
 echo "creating and funding the nonce account with 0.1 SOL"
 nonceAccount="nonce-keypair.json"
-solana-keygen new --no-bip39-passphrase -o $nonceAccount 
+solana-keygen new --no-bip39-passphrase -o $nonceAccount
 nonceAccountPubkey=`solana-keygen pubkey $nonceAccount`
 solana create-nonce-account $nonceAccount 0.1
 
-# more nonce configuration setup 
+# more nonce configuration setup
 blockhash=`solana nonce-account $nonceAccountPubkey | grep blockhash | xargs -n 1 | tail -n -1`
 echo "blockhash: $blockhash"
 nonceAuthority=$signer1
@@ -65,19 +71,14 @@ echo "nonceAuthorityPubkey: $nonceAuthorityPubkey"
 mintDecimals=9
 echo ""
 
+echo "------------Step 5. Sending WrappedSOL from multisig to signer2------------"
 ### This section is the multisig transfer with offline signature scheme
-# Currently, I believe this to be set up correctly, but results in "presigner error"
-# Looking for support to fix the bug / error I am experiencing
-
-
 # initialize
-spl-token create-account $wSOLTokenAddress --owner $signer1Pubkey # using signer1.json
-recipientTokenAddress=`spl-token account-info $wSOLTokenAddress $signer1Pubkey | grep Address | xargs -n 1 | tail -n -1 | sed 's/=/ /g' | xargs -n 1 | tail -n 1`
-echo "recipientTokenAddress: $recipientTokenAddress"
-echo ""
+# Replaced $recipientTokenAddress with $signer2Pubkey, for this added --recipient-is-ata-owner and --allow-unfunded-recipient
 echo "iniatizing the transaction"
-spl-token transfer $wSOLTokenAddress $amountActual $recipientTokenAddress \
+spl-token transfer $wSOLTokenAddress $amountActual $signer2Pubkey \
 --fund-recipient \
+--recipient-is-ata-owner \
 --sign-only \
 --blockhash $blockhash \
 --owner $multisigAddress \
@@ -90,8 +91,9 @@ spl-token transfer $wSOLTokenAddress $amountActual $recipientTokenAddress \
 
 # first signature
 echo "obtaining first signature"
-signature1=`spl-token transfer $wSOLTokenAddress $amountActual $recipientTokenAddress \
+signature1=`spl-token transfer $wSOLTokenAddress $amountActual $signer2Pubkey \
 --fund-recipient \
+--recipient-is-ata-owner \
 --sign-only \
 --blockhash $blockhash \
 --owner $multisigAddress \
@@ -105,8 +107,9 @@ echo ""
 
 #2nd signature
 echo "obtaining second signature"
-signature2=`spl-token transfer $wSOLTokenAddress $amountActual $recipientTokenAddress \
+signature2=`spl-token transfer $wSOLTokenAddress $amountActual $signer2Pubkey \
 --fund-recipient \
+--recipient-is-ata-owner \
 --sign-only \
 --blockhash $blockhash \
 --owner $multisigAddress \
@@ -120,11 +123,9 @@ echo ""
 
 # broadcast the transaction
 echo "commencing multisig transfer:"
-# Use RUST_BACKTRACE=1? How to troubleshoot the "presigner error"
-#USAGE:
-#    spl-token transfer <TOKEN_ADDRESS> <TOKEN_AMOUNT> <RECIPIENT_ADDRESS or RECIPIENT_TOKEN_ACCOUNT_ADDRESS> --blockhash <BLOCKHASH> --config <PATH> --from <SENDER_TOKEN_ACCOUNT_ADDRESS> --fund-recipient --mint-decimals <MINT_DECIMALS> --multisig-signer <MULTISIG_SIGNER>... --nonce <PUBKEY> --nonce-authority <KEYPAIR> --recipient-is-ata-owner --sign-only --signer <PUBKEY=SIGNATURE>...
-spl-token transfer $wSOLTokenAddress $amountActual $recipientTokenAddress \
+spl-token transfer $wSOLTokenAddress $amountActual $signer2Pubkey \
 --fund-recipient \
+--allow-unfunded-recipient \
 --blockhash $blockhash \
 --owner $multisigAddress \
 --multisig-signer $signer1Pubkey \
@@ -134,30 +135,32 @@ spl-token transfer $wSOLTokenAddress $amountActual $recipientTokenAddress \
 --signer $signature1 \
 --signer $signature2
 
-# println to console for debug ;)
-#echo "nonceAccountPubkey: $nonceAccountPubkey"
-#echo "nonceAuthorityPubkey: $nonceAuthorityPubkey"
-#echo "signer1Pubkey: $signer1Pubkey"
-#echo "signer2Pubkey: $signer2Pubkey"
-#echo "signer3Pubkey: $signer3Pubkey"
-#echo "recipient $recipient"
-#echo "recipientTokenAddress: $recipientTokenAddress"
+## println to console for debug ;)
+# echo "nonceAccountPubkey: $nonceAccountPubkey"
+# echo "nonceAuthorityPubkey: $nonceAuthorityPubkey"
+# echo "signer1Pubkey: $signer1Pubkey"
+# echo "signer2Pubkey: $signer2Pubkey"
+# echo "signer3Pubkey: $signer3Pubkey"
+# echo "recipientTokenAddress: $recipientTokenAddress"
 
 echo "wrapped sol has been sent."
 echo ""
 
+echo "------------Step 6.unwrap WrappedSOL and get native SOLs------------"
 ### --- SPL multisig transfer is done now. Below is just unwrapping it to native SOL ---
-#
 # Unwrap part 1: need the associated token address for the recipient wrapped SOL:
-echo "displaying the SPL token balance for $signer1"
-spl-token accounts # for $signer1 keypair
-SPLAccountAddress=`spl-token account-info $wSOLTokenAddress $recipient | grep Address | xargs -n 1 | tail -n -1`
+spl-token accounts --owner $multisigAddress
+spl-token accounts --owner $signer1Pubkey
+spl-token accounts --owner $signer2Pubkey
+
+SPLAccountAddress=`spl-token account-info $wSOLTokenAddress $signer2Pubkey | grep Address | xargs -n 1 | tail -n -1`
+spl-token account-info $wSOLTokenAddress $signer2Pubkey
 
 # Unwrap part 2: unwrap the SOL to native SOL:
-spl-token unwrap $SPLAccountAddress
+spl-token unwrap $SPLAccountAddress $signer2
 
-echo "displaying final balance in native SOL for ${signer1}, address $recipient"
-solana balance $recipient
-echo ""
+echo "displaying final balance in native SOL for ${signer2}"
+solana balance $signer2Pubkey
 
-echo "Demonstration complete: multisig wallet was created, round-trip wrapped sol transfer completed using Solana spl-token program."  
+echo "displaying final balance in native SOL for ${signer1}"
+solana balance $signer1Pubkey


### PR DESCRIPTION
The README is written in more detail. Changed token sending, it is closer to the real scenario, now so: signer1->multisig->signer2. Added the necessary flags for proper operation, as well as more logs in the script. 